### PR TITLE
Fix Connector provider and update magic-sdk version 

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
 import { Connector, Actions } from "@web3-react/types";
-import type { MagicSDKAdditionalConfiguration } from "magic-sdk";
-import { Magic } from "magic-sdk";
-import { Eip1193Bridge } from "@ethersproject/experimental";
+import { Magic, MagicSDKAdditionalConfiguration } from "magic-sdk";
+import { RPCProviderModule } from "@magic-sdk/provider/dist/types/modules/rpc-provider";
+import { AbstractProvider } from "web3-core";
 export interface MagicConnectorSDKOptions extends MagicSDKAdditionalConfiguration {
     apiKey: string;
     networkOptions: {
@@ -19,7 +19,7 @@ export interface MagicConnectConstructorArgs {
     onError?: (error: Error) => void;
 }
 export declare class MagicConnect extends Connector {
-    provider: Eip1193Bridge | undefined;
+    provider?: RPCProviderModule & AbstractProvider;
     magic?: Magic;
     private eagerConnection?;
     private readonly options;
@@ -30,6 +30,7 @@ export declare class MagicConnect extends Connector {
     private chainChangedListener;
     private accountsChangedListener;
     private isomorphicInitialize;
+    private handleActivation;
     /** {@inheritdoc Connector.connectEagerly} */
     connectEagerly(): Promise<void>;
     activate(): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,9 +14,6 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "@ethersproject/experimental": "^5.7.0",
-    "@ethersproject/providers": "^5.7.2",
-    "@magic-ext/connect": "^6.7.0",
     "@web3-react/types": "^8.1.2-beta.0",
     "magic-sdk": "^15",
     "typescript": "^5.0.2"


### PR DESCRIPTION
## Changes Made

- Update to `magic-sdk` version 15.0
- Remove `@magic-ext/connect` and `@ethersproject` dependencies. 
- Remove the `Eip1193Bridge` provider and instead uses the `RPCProviderModule` and `AbstractProvider` from `@magic-sdk/provider` and `web3-core`.